### PR TITLE
Extract beberapa method di model factory ke trait

### DIFF
--- a/database/factories/BusinessFactory.php
+++ b/database/factories/BusinessFactory.php
@@ -2,10 +2,8 @@
 
 namespace Database\Factories;
 
-use Creasi\Base\Models\Address;
 use Creasi\Base\Models\Business;
-use Creasi\Base\Models\Enums\FileUploadType;
-use Creasi\Base\Models\FileUpload;
+use Creasi\Base\Models\Concerns\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -13,6 +11,9 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class BusinessFactory extends Factory
 {
+    use Factories\WithAddress;
+    use Factories\WithFileUpload;
+
     protected $model = Business::class;
 
     /**
@@ -26,17 +27,5 @@ class BusinessFactory extends Factory
             'phone' => '08'.$this->faker->numerify('##########'),
             'summary' => $this->faker->sentence(4),
         ];
-    }
-
-    public function withAddress(): static
-    {
-        return $this->has(Address::factory());
-    }
-
-    public function withFileUpload(FileUploadType $type = null): static
-    {
-        return $this->hasAttached(FileUpload::factory(), [
-            'type' => $type ?? $this->faker->randomElement(FileUploadType::cases()),
-        ], 'files');
     }
 }

--- a/database/factories/PersonnelFactory.php
+++ b/database/factories/PersonnelFactory.php
@@ -2,16 +2,9 @@
 
 namespace Database\Factories;
 
-use Creasi\Base\Models\Address;
-use Creasi\Base\Models\Business;
-use Creasi\Base\Models\Enums\EmploymentStatus;
-use Creasi\Base\Models\Enums\EmploymentType;
-use Creasi\Base\Models\Enums\FileUploadType;
+use Creasi\Base\Models\Concerns\Factories;
 use Creasi\Base\Models\Enums\Gender;
-use Creasi\Base\Models\FileUpload;
 use Creasi\Base\Models\Personnel;
-use Creasi\Base\Models\Profile;
-use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -19,6 +12,10 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class PersonnelFactory extends Factory
 {
+    use Factories\AsPersonnel;
+    use Factories\WithAddress;
+    use Factories\WithFileUpload;
+
     protected $model = Personnel::class;
 
     /**
@@ -43,43 +40,5 @@ class PersonnelFactory extends Factory
         return $this->state([
             'user_id' => null,
         ]);
-    }
-
-    public function withProfile(Gender $gender = null): static
-    {
-        return $this->has(Profile::factory(), 'profile')->state(fn () => [
-            'name' => $this->faker->firstName($gender?->toFaker()),
-        ]);
-    }
-
-    public function withCompany(
-        bool $primary = null,
-        EmploymentType $type = null,
-        EmploymentStatus $status = null,
-        false|DateTimeInterface $startDate = null,
-    ): static {
-        if (null === $startDate) {
-            $startDate = $this->faker->dateTime();
-        }
-
-        return $this->hasAttached(Business::factory(), [
-            'is_primary' => $primary,
-            'type' => $type ?? $this->faker->randomElement(EmploymentType::cases()),
-            'status' => $status ?? $this->faker->randomElement(EmploymentStatus::cases()),
-            'start_date' => $startDate?->format('Y-m-d'),
-            'finish_date' => null,
-        ], 'employers');
-    }
-
-    public function withAddress(): static
-    {
-        return $this->has(Address::factory());
-    }
-
-    public function withFileUpload(FileUploadType $type = null): static
-    {
-        return $this->hasAttached(FileUpload::factory(), [
-            'type' => $type ?? $this->faker->randomElement(FileUploadType::cases()),
-        ], 'files');
     }
 }

--- a/database/factories/ProfileFactory.php
+++ b/database/factories/ProfileFactory.php
@@ -2,9 +2,7 @@
 
 namespace Database\Factories;
 
-use Creasi\Base\Models\Enums\Education;
-use Creasi\Base\Models\Enums\Religion;
-use Creasi\Base\Models\Enums\TaxStatus;
+use Creasi\Base\Models\Enums;
 use Creasi\Base\Models\Profile;
 use Creasi\Nusa\Models\Regency;
 use Illuminate\Contracts\Database\Query\Builder;
@@ -30,9 +28,9 @@ class ProfileFactory extends Factory
             'nik' => $nik = $this->faker->nik(null, $birthDate = $this->faker->dateTime()),
             'birth_date' => $birthDate->format('Y-m-d'),
             'birth_place_code' => $birthPlace->code,
-            'education' => $this->faker->randomElement(Education::cases()),
-            'religion' => $this->faker->randomElement(Religion::cases()),
-            'tax_status' => $this->faker->randomElement(TaxStatus::cases()),
+            'education' => $this->faker->randomElement(Enums\Education::cases()),
+            'religion' => $this->faker->randomElement(Enums\Religion::cases()),
+            'tax_status' => $this->faker->randomElement(Enums\TaxStatus::cases()),
             'tax_id' => $nik,
         ];
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,7 +2,7 @@
 
 namespace Database\Factories;
 
-use Creasi\Base\Models\Personnel;
+use Creasi\Base\Models\Concerns\Factories\WithIdentity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -11,6 +11,8 @@ use Illuminate\Support\Str;
  */
 class UserFactory extends Factory
 {
+    use WithIdentity;
+
     public function modelName()
     {
         return app('creasi.base.user_model');
@@ -40,14 +42,5 @@ class UserFactory extends Factory
         return $this->state([
             'email_verified_at' => null,
         ]);
-    }
-
-    public function withIdentity(\Closure $cb = null): static
-    {
-        if ($cb === null) {
-            $cb = fn (PersonnelFactory $identity) => $identity->withProfile();
-        }
-
-        return $this->has($cb(Personnel::factory()), 'identity');
     }
 }

--- a/src/Models/Business.php
+++ b/src/Models/Business.php
@@ -12,7 +12,7 @@ use Creasi\Base\Models\Concerns\WithTaxInfo;
  *
  * @method static \Database\Factories\BusinessFactory<static> factory()
  */
-class Business extends Entity implements HasTaxInfo, Company
+class Business extends Entity implements Company, HasTaxInfo
 {
     use AsCompany;
     use WithTaxInfo;

--- a/src/Models/Concerns/Factories/AsPersonnel.php
+++ b/src/Models/Concerns/Factories/AsPersonnel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Creasi\Base\Models\Concerns\Factories;
+
+use Creasi\Base\Models\Business;
+use Creasi\Base\Models\Enums;
+use Creasi\Base\Models\Profile;
+use DateTimeInterface;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Factories\Factory
+ */
+trait AsPersonnel
+{
+    public function withProfile(Enums\Gender $gender = null): static
+    {
+        return $this->has(Profile::factory(), 'profile')->state(fn () => [
+            'name' => $this->faker->firstName($gender?->toFaker()),
+        ]);
+    }
+
+    public function withCompany(
+        bool $primary = null,
+        Enums\EmploymentType $type = null,
+        Enums\EmploymentStatus $status = null,
+        false|DateTimeInterface $startDate = null,
+    ): static {
+        if ($startDate === null) {
+            $startDate = $this->faker->dateTime();
+        }
+
+        return $this->hasAttached(Business::factory(), [
+            'is_primary' => $primary,
+            'type' => $type ?? $this->faker->randomElement(Enums\EmploymentType::cases()),
+            'status' => $status ?? $this->faker->randomElement(Enums\EmploymentStatus::cases()),
+            'start_date' => $startDate?->format('Y-m-d'),
+            'finish_date' => null,
+        ], 'employers');
+    }
+}

--- a/src/Models/Concerns/Factories/WithAddress.php
+++ b/src/Models/Concerns/Factories/WithAddress.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Creasi\Base\Models\Concerns\Factories;
+
+use Creasi\Base\Models\Address;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Factories\Factory
+ */
+trait WithAddress
+{
+    public function withAddress(): static
+    {
+        return $this->has(Address::factory());
+    }
+}

--- a/src/Models/Concerns/Factories/WithFileUpload.php
+++ b/src/Models/Concerns/Factories/WithFileUpload.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Creasi\Base\Models\Concerns\Factories;
+
+use Creasi\Base\Models\Enums\FileUploadType;
+use Creasi\Base\Models\FileUpload;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Factories\Factory
+ */
+trait WithFileUpload
+{
+    public function withFileUpload(FileUploadType $type = null): static
+    {
+        return $this->hasAttached(FileUpload::factory(), [
+            'type' => $type ?? $this->faker->randomElement(FileUploadType::cases()),
+        ], 'files');
+    }
+}

--- a/src/Models/Concerns/Factories/WithIdentity.php
+++ b/src/Models/Concerns/Factories/WithIdentity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Creasi\Base\Models\Concerns\Factories;
+
+use Creasi\Base\Models\Personnel;
+use Database\Factories\PersonnelFactory;
+
+/**
+ * @mixin \Illuminate\Database\Eloquent\Factories\Factory
+ */
+trait WithIdentity
+{
+    public function withIdentity(\Closure $cb = null): static
+    {
+        if ($cb === null) {
+            $cb = fn (PersonnelFactory $identity) => $identity->withProfile();
+        }
+
+        return $this->has($cb(Personnel::factory()), 'identity');
+    }
+}


### PR DESCRIPTION
Tujuan utama adanya model factory adalah untuk mempermudah kita untuk meng-generate data yang dibutuhkan untuk tiap model pada saat melakukan pengujian.

Namun dikarenakan factory class yang ada di package ini tidak disertakan dalam distribusi (saat package ini di install di app), perlu ada cara bagi developer untuk dapat tetap fitur yang perlu ada tanpa perlu menulis ulang.

Contoh untuk `UserFactory`, by default installasi laravel sudah memiliki class `Database\Factories\UserFactory` didalam folder `database/factories` maka developer cukup menggunakan trait [`WithIdentity`](https://github.com/creasico/laravel-base/blob/ae5191391a863a24d344b42046347bb423015014/src/Models/Concerns/Factories/WithIdentity.php) untuk dapat meng-generate user beserta identity yang dibutuhkan

```php
namespace Database\Factories;

use Creasi\Base\Models\Concerns\Factories\WithIdentity;
use Illuminate\Database\Eloquent\Factories\Factory;

class UserFactory extends Factory
{
    use WithIdentity;

    ...
}

// Sample
App\Models\User::factory()->withIdentity();
```

Agar bisa meng-generate User beserta Identity (Profile) yang dibutuhkan