### PR TITLE
feat: initialize `user_devices` resources

### DIFF
--- a/database/migrations/2022_05_10_000001_create_identities_address_and_files_table.php
+++ b/database/migrations/2022_05_10_000001_create_identities_address_and_files_table.php
@@ -11,6 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        Schema::create('user_devices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('token');
+        });
+
         Schema::create('profiles', function (Blueprint $table) {
             $table->id();
             $table->nullableMorphs('identity');

--- a/src/Contracts/HasDevices.php
+++ b/src/Contracts/HasDevices.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Creasi\Base\Contracts;
+
+/**
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Creasi\Base\Models\UserDevice> $devices
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
+interface HasDevices
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function devices();
+}

--- a/src/Events/UserDeviceRegistered.php
+++ b/src/Events/UserDeviceRegistered.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Creasi\Base\Events;
+
+use Creasi\Base\Models\UserDevice;
+
+class UserDeviceRegistered
+{
+    public function __construct(
+        public UserDevice $device
+    ) {
+        // .
+    }
+}

--- a/src/Listeners/RegisterUserDevice.php
+++ b/src/Listeners/RegisterUserDevice.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Creasi\Base\Listeners;
+
+use Creasi\Base\Events\UserDeviceRegistered;
+use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Http\Request;
+
+class RegisterUserDevice
+{
+    public function __construct(
+        private Request $request
+    ) {
+        // .
+    }
+
+    public function handle(Authenticated $event)
+    {
+        if (! $this->request->filled('device')) {
+            return;
+        }
+
+        /** @var \Creasi\Base\Contracts\HasDevices */
+        $user = $event->user;
+
+        $device = $user->devices()->firstOrCreate([
+            'device' => $this->request->input('device'),
+        ]);
+
+        \event(new UserDeviceRegistered($device));
+    }
+}

--- a/src/Models/Concerns/WithDevices.php
+++ b/src/Models/Concerns/WithDevices.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Creasi\Base\Models\Concerns;
+
+use Creasi\Base\Models\UserDevice;
+
+/**
+ * @mixin \Illuminate\Foundation\Auth\User
+ */
+trait WithDevices
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function devices()
+    {
+        return $this->hasMany(UserDevice::class);
+    }
+}

--- a/src/Models/UserDevice.php
+++ b/src/Models/UserDevice.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Creasi\Base\Models;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+/**
+ * @property string $token
+ * @property-read \App\Models\User $user
+ */
+class UserDevice extends EloquentModel
+{
+    protected $fillable = [
+        'token',
+    ];
+
+    public $timestamps = false;
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo|Personnel
+     */
+    public function user()
+    {
+        return $this->belongsTo('\App\Models\User');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,9 @@ use Creasi\Base\Models\Address;
 use Creasi\Base\Models\Entity;
 use Creasi\Base\Models\Enums\BusinessRelativeType;
 use Creasi\Base\View\Composers\TranslationsComposer;
+use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
@@ -64,6 +66,10 @@ class ServiceProvider extends IlluminateServiceProvider
         }
 
         $this->registerBindings();
+
+        $this->booting(function (): void {
+            Event::listen(Authenticated::class, Listeners\RegisterUserDevice::class);
+        });
     }
 
     protected function registerPublishables(): void

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -3,6 +3,7 @@
 namespace Creasi\Tests\Fixtures;
 
 use Creasi\Base\Contracts\HasIdentity;
+use Creasi\Base\Models\Concerns\WithDevices;
 use Creasi\Base\Models\Concerns\WithIdentity;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -25,6 +26,7 @@ class User extends Authenticatable implements HasIdentity
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use WithDevices;
     use WithIdentity;
 
     protected static function newFactory()


### PR DESCRIPTION
Add functionality to register user' device right after user authenticated in regards of enable push notification for all devices belongs to user.

As of now, the we only store `device_token` provided by firebase client library just to prove the concept.